### PR TITLE
Fix error when ReplicatedStorage is renamed

### DIFF
--- a/src/ReplicatedStorage/ReplicaClient.luau
+++ b/src/ReplicatedStorage/ReplicaClient.luau
@@ -68,7 +68,9 @@ MAD STUDIO
 
 ----- Dependencies -----
 
-local ReplicaShared = game.ReplicatedStorage.ReplicaShared
+local CollectionService = game:GetService("CollectionService")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local ReplicaShared = ReplicatedStorage.ReplicaShared
 local Remote = require(ReplicaShared.Remote)
 local Signal = require(ReplicaShared.Signal)
 local Maid = require(ReplicaShared.Maid)
@@ -79,10 +81,6 @@ local BIND_TAG = "Bind"
 local CS_TAG = "REPLICA" -- CollectionService tag
 local MAID_LOCK = {}
 local REQUEST_DATA_REPEAT = 2
-
-local CollectionService = game:GetService("CollectionService")
-local ReplicatedStorage = game:GetService("ReplicatedStorage")
-local Players = game:GetService("Players")
 
 local DataRequestStarted = false
 

--- a/src/ServerScriptService/ReplicaServer.luau
+++ b/src/ServerScriptService/ReplicaServer.luau
@@ -85,7 +85,10 @@ MAD STUDIO
 
 ----- Dependencies -----
 
-local ReplicaShared = game.ReplicatedStorage.ReplicaShared
+local CollectionService = game:GetService("CollectionService")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local Players = game:GetService("Players")
+local ReplicaShared = ReplicatedStorage.ReplicaShared
 local RateLimit = require(ReplicaShared.RateLimit)
 local Remote = require(ReplicaShared.Remote)
 local Signal = require(ReplicaShared.Signal)
@@ -98,10 +101,6 @@ local CS_TAG = "REPLICA" -- CollectionService tag
 local REPLICATION_ALL = "ALL"
 local MAID_LOCK = {}
 local EMPTY_TABLE = {}
-
-local CollectionService = game:GetService("CollectionService")
-local ReplicatedStorage = game:GetService("ReplicatedStorage")
-local Players = game:GetService("Players")
 
 local GlobalRateLimit = RateLimit.New(120)
 


### PR DESCRIPTION
Fixes "ReplicatedStorage is not a valid member of DataModel" error when ReplicatedStorage is renamed.