### PR TITLE
SetValues now fires set_listeners

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+sourcemap.json

--- a/aftman.toml
+++ b/aftman.toml
@@ -3,5 +3,5 @@
 
 # To add a new tool, add an entry to this table.
 [tools]
-rojo = "rojo-rbx/rojo@7.4.4"
+rojo = "rojo-rbx/rojo@7.7.0-rc.1"
 # rojo = "rojo-rbx/rojo@6.2.0"

--- a/src/ReplicatedStorage/ReplicaClient.luau
+++ b/src/ReplicatedStorage/ReplicaClient.luau
@@ -372,6 +372,16 @@ function Replica:IsActive(): boolean
 	return self.Maid:IsActive()
 end
 
+-- Internal function to fire set listeners for a path
+function Replica:FireSetListeners(path: {string}, value: any, old_value: any)
+	if next(self.set_listeners) ~= nil then
+		local listeners = self.set_listeners[table.concat(path, ".")]
+		if listeners ~= nil then
+			listeners:Fire(value, old_value)
+		end
+	end
+end
+
 function Replica:Set(path: {string}, value: any)
 	
 	if ReplicationFlag ~= true then
@@ -390,12 +400,7 @@ function Replica:Set(path: {string}, value: any)
 	
 	-- Firing signals:
 	
-	if next(self.set_listeners) ~= nil then
-		local listeners = self.set_listeners[table.concat(path, ".")]
-		if listeners ~= nil then
-			listeners:Fire(value, old_value)
-		end
-	end
+	self:FireSetListeners(path, value, old_value)
 	self.changed_listeners:Fire("Set", path, value, old_value)
 	
 end
@@ -413,7 +418,13 @@ function Replica:SetValues(path: {string}, values: {[string]: any})
 		pointer = pointer[key]
 	end
 	for key, value in pairs(values) do
+		local old_value = pointer[key]
 		pointer[key] = value
+
+		-- Fire set listeners
+		local new_path = table.clone(path)
+		table.insert(new_path, key)
+		self:FireSetListeners(new_path, value, old_value)
 	end
 	
 	-- Firing signals:

--- a/src/ServerScriptService/ReplicaServer.luau
+++ b/src/ServerScriptService/ReplicaServer.luau
@@ -219,6 +219,8 @@ export type Replica = {
 	Maid: typeof(Maid),
 
 	Set: (self: any, path: {string}, value: any) -> (),
+	Update: <T>(self: any, path: {string}, fun: (T) -> (T)) -> (),
+	Increment: (self: any, path: {string}, value: number) -> (),
 	SetValues: (self: any, path: {string}, values: {[string]: any}) -> (),
 	TableInsert: (self: any, path: {string}, value: any, index: number?) -> (number),
 	TableRemove: (self: any, path: {string}, index: number) -> (any),
@@ -363,6 +365,20 @@ function Replica:Set(path: {string}, value: any)
 		end
 	end
 	
+end
+
+function Replica:Update<T>(path: {string}, fun: (T) -> (T))
+	-- Get value
+	local pointer = self.Data
+	for i = 1, #path - 1 do
+		pointer = pointer[path[i]]	
+	end
+	
+	self:Set(path, fun(pointer[path[#path]]))
+end
+
+function Replica:Increment(path: {string}, value: number)
+	self:Update(path, function(v) return v + value end)
 end
 
 function Replica:SetValues(path: {string}, values: {[string]: any})


### PR DESCRIPTION
This fixes an issue where calling Replica.SetValues() on the server does not fire listeners created by Replica.OnSet on the client